### PR TITLE
Temporary hack due to Vankrupt API instability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "PavlovReplayToolbox"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "chrono",
  "directories",
@@ -3424,9 +3424,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "PavlovReplayToolbox"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [dependencies]
@@ -10,7 +10,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 chrono = "0.4.44"
 rfd = "0.17.2"
-reqwest = { version = "0.13.3", features = ["blocking", "json"] }
+reqwest = { version = "0.13.4", features = ["blocking", "json"] }
 image = "0.25.10"
 directories = "6.0.0"
 rayon = "1.12.0"

--- a/src/tools/replay_processor.rs
+++ b/src/tools/replay_processor.rs
@@ -453,11 +453,17 @@ pub fn download_replay(
     update_progress(completed_components);
 
     // Get events
-    let events: EventsWrapper = get_json(
+    let events: EventsWrapper = match get_json(
         &client,
         &format!("{}/replay/{}/event?group=checkpoint", SERVER, replay_id),
         max_retries,
-    )?;
+    ) //? 
+      //(THIS IS A HACK TO AVOID FAILING THE ENTIRE DOWNLOAD IF CHECKPOINT EVENTS ARE UNAVAILABLE) 
+      // Vankrupt's server can and will shit itself and treturn 502 errors on this endpoint.
+    {
+        Ok(events) => events,
+        Err(_) => EventsWrapper { events: Vec::new() },
+    };
     replay_data.insert("events".into(), serde_json::to_value(&events)?);
     
     completed_components += 1;


### PR DESCRIPTION
We're just going to skip Checkpoint events on error/timeout.
They're not strictly required for the replay to be valid.

This should make replays that have this issue downloadable.